### PR TITLE
private npm repo support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-plugin-googlemaps-sdk",
+  "name": "@dronesense/cordova-plugin-googlemaps-sdk",
   "version": "2.7.0",
   "description": "Google Maps SDK for iOS for Cordova (files are copied from Google)",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<plugin id="com.googlemaps.ios" version="2.7.0" xmlns="http://apache.org/cordova/ns/plugins/1.0">
+<plugin id="cordova-plugin-googlemaps-sdk" version="2.7.0" xmlns="http://apache.org/cordova/ns/plugins/1.0">
   <name>Google Maps SDK for iOS</name>
   <description>Install the Google Maps SDK for iOS without CocoaPods</description>
   <keywords>cordova, ios, googlemaps</keywords>


### PR DESCRIPTION
This is now publishable to our private npm repo. There was a problem with this plugin taking an infinite amount of time to get sometimes, and I think that was because it was pulled from github. 